### PR TITLE
Fix memory management

### DIFF
--- a/include/diagram.h
+++ b/include/diagram.h
@@ -60,8 +60,6 @@ public:
     /// @return A random diagram
     static Diagram random(size_t height);
 
-    static Diagram *randomPointer(size_t height);
-
     /// @brief Populate the diagram with random values
     void populate(const size_t totalHeight = 0);
 
@@ -109,7 +107,6 @@ public:
 
     void markParentsAsToBeUpdated();
 
-    std::vector<Diagram *> parents;
 
     /// @brief Is the data stored at node-level up-to-date
     bool isUpToDate = false;
@@ -125,6 +122,15 @@ public:
 protected:
     /// @brief The enclosure value if `isUpToDate` is true
     Interval cachedEnclosure;
+
+    /** @brief The parents of the node
+     * @details This is used to propagate changes in the children to the parents. righto and lefto
+     * should update the parents of the children.
+    */
+    std::vector<Diagram *> parents;
+
+    /// @brief Forget a child
+    void forgetChild(Diagram *d) noexcept;
 };
 
 Interval calculateEnclosure(Diagram &d);

--- a/include/qasm/gate.h
+++ b/include/qasm/gate.h
@@ -10,7 +10,7 @@
 /// @brief A quantum gate
 class Gate {
 public:
-    static bool exists(const std::string& gateName);
+    [[nodiscard]] static bool exists(const std::string &gateName) noexcept;
     [[nodiscard]] static const Gate byName(const std::string &gateName);
     void applyTo(const std::vector<varname>& qubitsNames) const;
     virtual void applyTo(const std::vector<qubit>& qubits) const;

--- a/include/qasm/gate.h
+++ b/include/qasm/gate.h
@@ -11,7 +11,7 @@
 class Gate {
 public:
     static bool exists(const std::string& gateName);
-    static const Gate* byName(const std::string& gateName);
+    [[nodiscard]] static const Gate byName(const std::string &gateName);
     void applyTo(const std::vector<varname>& qubitsNames) const;
     virtual void applyTo(const std::vector<qubit>& qubits) const;
 

--- a/include/qasm/gate.h
+++ b/include/qasm/gate.h
@@ -8,12 +8,13 @@
 #include <vector>
 
 /// @brief A quantum gate
-class Gate {
+class Gate
+{
 public:
     [[nodiscard]] static bool exists(const std::string &gateName) noexcept;
     [[nodiscard]] static const Gate byName(const std::string &gateName);
-    void applyTo(const std::vector<varname>& qubitsNames) const;
-    virtual void applyTo(const std::vector<qubit>& qubits) const;
+    void applyTo(const std::vector<varname> &qubitsNames) const;
+    virtual void applyTo(const std::vector<qubit> &qubits) const;
 
     /// @brief The number of qubits of the gate
     std::size_t size() const noexcept;
@@ -21,20 +22,23 @@ public:
     std::string toString() const noexcept;
 
     const std::string name;
+
 protected:
-    Gate(const std::string& name, const std::size_t size);
+    Gate(const std::string &name, const std::size_t size);
     const std::size_t gateSize;
 };
 
 /// @brief A phase gate
-class PhaseGate : public Gate {
+class PhaseGate : public Gate
+{
 public:
-    static bool is(const std::string& gateName);
-    PhaseGate(const std::string& gateName);
+    [[nodiscard]] static bool is(const std::string &gateName);
+    PhaseGate(const std::string &gateName);
 
     const int phase;
+
 protected:
     PhaseGate(int phase);
 };
 
-std::string gateToString(const std::string& name);
+std::string gateToString(const std::string &name);

--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -225,6 +225,16 @@ void Diagram::markParentsAsToBeUpdated()
     }
 }
 
+void Diagram::forgetChild(Diagram *d) noexcept
+{
+    right.erase(std::remove_if(right.begin(), right.end(), [d](branch b)
+                               { return b.d == d; }),
+                right.end());
+    left.erase(std::remove_if(left.begin(), left.end(), [d](branch b)
+                              { return b.d == d; }),
+               left.end());
+}
+
 Diagram::~Diagram()
 {
     for (branch b : left)
@@ -234,6 +244,12 @@ Diagram::~Diagram()
     for (branch b : right)
     {
         delete b.d;
+    }
+    for (Diagram *p : parents)
+    {
+        p->isUpToDate = false;
+        p->markParentsAsToBeUpdated();
+        p->forgetChild(this);
     }
 }
 

--- a/src/qasm/gate.cpp
+++ b/src/qasm/gate.cpp
@@ -79,31 +79,19 @@ bool Gate::exists(const std::string &gateName)
     return isReservedName(gateName) || PhaseGate::is(gateName);
 }
 
-const Gate *Gate::byName(const std::string &gateName)
+const Gate Gate::byName(const std::string &gateName)
 {
-    static const Gate X = Gate("x", 1);
-    static const Gate H = Gate("h", 1);
-    static const Gate CX = Gate("cx", 2);
-    static const Gate S = Gate("s", 2);
     if (PhaseGate::is(gateName))
     {
-        return new PhaseGate(gateName);
+        return PhaseGate(gateName);
     }
-    else if (gateName == X.name)
+    else if (gateName == "x" || gateName == "h")
     {
-        return &X;
+        return Gate(gateName, 1);
     }
-    else if (gateName == H.name)
+    else if (gateName == "s" || gateName == "cx")
     {
-        return &H;
-    }
-    else if (gateName == CX.name)
-    {
-        return &CX;
-    }
-    else if (gateName == S.name)
-    {
-        return &S;
+        return Gate(gateName, 2);
     }
     throw VariableError("Undefined gate " + gateName);
 }
@@ -131,7 +119,7 @@ std::string gateToString(const std::string &name)
 {
     if (Gate::exists(name))
     {
-        return Gate::byName(name)->toString();
+        return Gate::byName(name).toString();
     }
     throw VariableError("Undefined gate: " + name);
 }

--- a/src/qasm/gate.cpp
+++ b/src/qasm/gate.cpp
@@ -74,7 +74,7 @@ PhaseGate::PhaseGate(int phase)
 {
 }
 
-bool Gate::exists(const std::string &gateName)
+bool Gate::exists(const std::string &gateName) noexcept
 {
     return isReservedName(gateName) || PhaseGate::is(gateName);
 }

--- a/src/qasm/statements.cpp
+++ b/src/qasm/statements.cpp
@@ -144,7 +144,7 @@ public:
     void execute() const override
     {
         auto gate = Gate::byName(gateName);
-        gate->applyTo(qubitsNames);
+        gate.applyTo(qubitsNames);
     };
 
     std::string gateName;

--- a/src/random-diagram.cpp
+++ b/src/random-diagram.cpp
@@ -14,13 +14,6 @@ Diagram Diagram::random(const size_t height)
     return d;
 }
 
-Diagram* Diagram::randomPointer(const size_t height)
-{
-    auto d = new Diagram(height);
-    d->populate(height);
-    return d;
-}
-
 void Diagram::populate(const size_t totalHeight)
 {
     if (height == 0) {

--- a/test/gateappliers_test.cpp
+++ b/test/gateappliers_test.cpp
@@ -8,16 +8,7 @@ size_t flipNthBit(const size_t n, const size_t index)
     return index ^ (1 << n);
 }
 
-class GateAppliersTest : public testing::Test
-{
-public:
-    Diagram *leaf = new Diagram(0);
-    Diagram *eig0 = Diagram::eig0(1);
-    Diagram *eig1 = new Diagram(1);
-    Diagram *dgm = new Diagram(2);
-};
-
-TEST_F(GateAppliersTest, X)
+TEST(GateAppliersTest, X)
 {
     for (auto numberOfQubits = 1; numberOfQubits < MAX_QUBITS; numberOfQubits++)
     {
@@ -50,7 +41,7 @@ TEST_F(GateAppliersTest, X)
     }
 }
 
-TEST_F(GateAppliersTest, phase)
+TEST(GateAppliersTest, phase)
 {
     for (auto numberOfQubits = 1; numberOfQubits < MAX_QUBITS; numberOfQubits++)
     {
@@ -90,7 +81,7 @@ TEST_F(GateAppliersTest, phase)
     }
 }
 
-TEST_F(GateAppliersTest, gateMatrixIdentity)
+TEST(GateAppliersTest, gateMatrixIdentity)
 {
     for (auto numberOfQubits = 1; numberOfQubits < MAX_QUBITS; numberOfQubits++)
     {
@@ -122,7 +113,7 @@ TEST_F(GateAppliersTest, gateMatrixIdentity)
     }
 }
 
-TEST_F(GateAppliersTest, gateMatrixHadamardOnQubit0)
+TEST(GateAppliersTest, gateMatrixHadamardOnQubit0)
 {
     absi::Interval coefficients[] = {1, 1, 1, -1};
     gateappliers::GateMatrix gate(1, coefficients);
@@ -141,7 +132,7 @@ TEST_F(GateAppliersTest, gateMatrixHadamardOnQubit0)
     EXPECT_EQ(ev[3], Interval::real(-2)) << ev[3].to_string() << " != -2";
 }
 
-TEST_F(GateAppliersTest, gateMatrixHadamardOnQubit1)
+TEST(GateAppliersTest, gateMatrixHadamardOnQubit1)
 {
     absi::Interval v[] = {1, 1, 1, -1};
     gateappliers::GateMatrix m(1, v);
@@ -166,7 +157,7 @@ TEST_F(GateAppliersTest, gateMatrixHadamardOnQubit1)
     }
 }
 
-TEST_F(GateAppliersTest, applyHConsistency)
+TEST(GateAppliersTest, applyHConsistency)
 {
     auto h = gateappliers::GateMatrix(1);
     h(0, 0) = ampl::invSqrt2;
@@ -194,7 +185,7 @@ TEST_F(GateAppliersTest, applyHConsistency)
     }
 }
 
-TEST_F(GateAppliersTest, applyS)
+TEST(GateAppliersTest, applyS)
 {
     ampl::Amplitude v[] = {1, 2, 3, 4};
     ampl::ConcreteState base(2, v);
@@ -210,7 +201,7 @@ TEST_F(GateAppliersTest, applyS)
     EXPECT_EQ(ev[3], 4) << ev[3].to_string() << " != 4";
 }
 
-TEST_F(GateAppliersTest, applyCX)
+TEST(GateAppliersTest, applyCX)
 {
     ampl::Amplitude v[] = {1, 2, 3, 4};
     ampl::ConcreteState base(2, v);
@@ -226,7 +217,7 @@ TEST_F(GateAppliersTest, applyCX)
     EXPECT_EQ(ev[3], 3) << ev[3].to_string() << " != 3";
 }
 
-TEST_F(GateAppliersTest, applyCXOnQubit1and2)
+TEST(GateAppliersTest, applyCXOnQubit1and2)
 {
     ampl::Amplitude v[] = {1, 2, 3, 4, 5, 6, 7, 8};
     ampl::ConcreteState base(3, v);
@@ -246,7 +237,7 @@ TEST_F(GateAppliersTest, applyCXOnQubit1and2)
     }
 }
 
-TEST_F(GateAppliersTest, applyH)
+TEST(GateAppliersTest, applyH)
 {
     const ampl::Amplitude v[] = {1, 0, 0, 0};
     const ampl::Amplitude afterH[] = {ampl::invSqrt2, 0, ampl::invSqrt2, 0};

--- a/test/gateappliers_test.cpp
+++ b/test/gateappliers_test.cpp
@@ -177,12 +177,12 @@ TEST_F(GateAppliersTest, applyHConsistency)
     const auto numberOfQubits = 4;
     for (auto q = 0; q < numberOfQubits; q++)
     {
-        auto d0 = Diagram::randomPointer(numberOfQubits);
-        auto d1 = d0->clone();
-        gateappliers::applyGateMatrix(d0, q, h);
+        auto d0 = Diagram::random(numberOfQubits);
+        auto d1 = d0.clone();
+        gateappliers::applyGateMatrix(&d0, q, h);
         gateappliers::applyH(d1, q);
 
-        auto e0 = d0->evaluate();
+        auto e0 = d0.evaluate();
         auto e1 = d1->evaluate();
         for (auto i = 0; i < e0.size(); i++)
         {


### PR DESCRIPTION
Several **memory safety related** changes to the `Diagram` and `Gate` classes, as well as updates to the associated tests. The most important changes include the removal of the `randomPointer` method and the modification of the `Gate::byName` constructor.

### Diagram Class Changes:
* Removed the `randomPointer` method and added the `forgetChild` method to manage child diagrams. (`include/diagram.h`, `src/diagram.cpp`, `src/random-diagram.cpp`)
* Moved the `parents` vector to the protected section and added documentation for it. (`include/diagram.h`)
* Updated the destructor to ensure parent diagrams are notified and updated when a child is deleted. (`src/diagram.cpp`)

### Gate Class Changes:
* Added `noexcept` specifier and `[[nodiscard]]` attribute to `exists` and `byName` methods. (`include/qasm/gate.h`, `src/qasm/gate.cpp`)
* Changed `byName` to return `Gate` by value instead of a pointer. (`include/qasm/gate.h`, `src/qasm/gate.cpp`)
* Updated the `GateApplyStatement::execute` method to reflect changes in `Gate::byName` return type. (`src/qasm/statements.cpp`)

### Test Updates:
* Removed the use of `TEST_F` in favor of `TEST` in the gate applier tests and updated the tests to reflect changes in the `Diagram` class. (`test/gateappliers_test.cpp`)