### PR TITLE
Speed up builds

### DIFF
--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -22,18 +22,18 @@ jobs:
         version: 1.12.1
 
     - name: Configure CMake
-      run: cmake -S $GITHUB_WORKSPACE -B ${{runner.workspace}}/build -GNinja
+      run: cmake -S $GITHUB_WORKSPACE -B ${{github.workspace}}/build -GNinja
 
     - name: Build
-      working-directory: ${{runner.workspace}}
+      working-directory: ${{github.workspace}}/build
       run: cmake --build build
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ${{github.workspace}}/build
       run: GTEST_OUTPUT=xml:test-results/ GTEST_COLOR=1 ctest -V
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
         name: test_results_xml
-        path: ${{runner.workspace}}/build/test-results/**/*.xml
+        path: ${{github.workspace}}/build/test-results/**/*.xml

--- a/.github/workflows/ci-cmake_tests.yml
+++ b/.github/workflows/ci-cmake_tests.yml
@@ -25,7 +25,7 @@ jobs:
       run: cmake -S $GITHUB_WORKSPACE -B ${{github.workspace}}/build -GNinja
 
     - name: Build
-      working-directory: ${{github.workspace}}/build
+      working-directory: ${{github.workspace}}
       run: cmake --build build
 
     - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,7 @@ include_directories(include/)
 
 enable_testing()
 
-set(absi_files src/absi/polar.cpp src/absi/cartesian.cpp)
 set(absi_libs cartesian polar amplitude)
-set(src_files src/amplitude.cpp ${absi_files} src/selection.cpp src/reduction.cpp)
-set(header_files include/amplitude.h include/qdd.h include/absi.h)
-set(test_files test/amplitude_test.cpp test/qdd_test.cpp test/absi_test.cpp test/selection_test.cpp test/reduction_test.cpp test/diagram_test.cpp)
-set(pasrc src/powarray.cpp src/powmatrix.cpp)
 
 set(sources
     ${src_files}
@@ -33,50 +28,59 @@ set(sources
     )
 
 # PowArray library
-add_library(powarray ${pasrc} src/absi/polar.cpp src/absi/cartesian.cpp)
+add_library(powarray src/powarray.cpp src/powmatrix.cpp src/absi/polar.cpp src/absi/cartesian.cpp)
 
 # Amplitude test
 add_library(amplitude src/amplitude.cpp)
 add_executable(amplitude_test test/amplitude_test.cpp)
-target_link_libraries(amplitude_test cartesian polar amplitude powarray GTest::gtest_main)
+target_link_libraries(amplitude_test amplitude powarray GTest::gtest_main)
 
 # ABStract Interpretation (ABSI) tests
 # Encompasses cartesian intervals test and polar intervals tests
 add_library(cartesian src/absi/cartesian.cpp)
+target_link_libraries(cartesian amplitude)
 add_library(polar src/absi/polar.cpp)
+
+add_library(absi INTERFACE)
+target_link_libraries(absi INTERFACE amplitude cartesian polar powarray)
+
 add_executable(absi_test test/absi_test.cpp)
-target_link_libraries(absi_test ${absi_libs} powarray GTest::gtest_main)
+target_link_libraries(absi_test absi GTest::gtest_main)
 
 # Diagram test
-add_library(diagram STATIC src/diagram.cpp src/random-diagram.cpp ${absi_files} src/amplitude.cpp)
+add_library(diagram STATIC src/diagram.cpp src/random-diagram.cpp)
+target_link_libraries(diagram absi)
 add_executable(diagram_test test/diagram_test.cpp)
-target_link_libraries(diagram_test powarray ${absi_libs} diagram GTest::gtest_main)
+target_link_libraries(diagram_test diagram GTest::gtest_main)
 
 # Selection test
-add_library(selection STATIC src/selection.cpp src/diagram.cpp ${absi_files} src/amplitude.cpp ${pasrc})
+add_library(selection STATIC src/selection.cpp)
+target_link_libraries(selection diagram)
 add_executable(selection_test test/selection_test.cpp)
-target_link_libraries(selection_test ${absi_libs} selection GTest::gtest_main)
+target_link_libraries(selection_test selection GTest::gtest_main)
 
 # Gate appliers test
-add_library(gateappliers STATIC src/gateappliers.cpp src/diagram.cpp ${absi_files} src/amplitude.cpp ${pasrc})
+add_library(gateappliers STATIC src/gateappliers.cpp)
+target_link_libraries(gateappliers diagram)
 add_executable(gateappliers_test test/gateappliers_test.cpp)
-target_link_libraries(gateappliers_test powarray ${absi_libs} diagram gateappliers GTest::gtest_main)
+target_link_libraries(gateappliers_test gateappliers GTest::gtest_main)
 
 # Reduction test
-add_library(reduction STATIC src/reduction.cpp src/selection.cpp src/diagram.cpp ${absi_files} src/amplitude.cpp)
+add_library(reduction STATIC src/reduction.cpp)
+target_link_libraries(reduction selection)
 add_executable(reduction_test test/reduction_test.cpp)
-target_link_libraries(reduction_test ${absi_libs} diagram selection reduction GTest::gtest_main)
+target_link_libraries(reduction_test reduction GTest::gtest_main)
 
 # QASM library
 FILE(GLOB QasmSources src/qasm/*.cpp)
-add_library(qasm STATIC ${QasmSources} src/diagram.cpp ${absi_files} src/amplitude.cpp ${pasrc} src/gateappliers.cpp)
+add_library(qasm STATIC ${QasmSources})
+target_link_libraries(qasm gateappliers)
 add_executable(qasm_test test/qasm/qasm_test.cpp)
-target_link_libraries(qasm_test powarray ${absi_libs} diagram qasm GTest::gtest_main)
+target_link_libraries(qasm_test qasm GTest::gtest_main)
 
 # Command-line prompt
-add_executable(prompt)
-target_sources(prompt PUBLIC src/prompt.cpp)
-target_link_libraries(prompt powarray ${absi_libs} diagram qasm)
+add_executable(prompt src/prompt.cpp src/amplitude.cpp)
+target_link_libraries(prompt qasm)
 
 include(GoogleTest)
 gtest_discover_tests(amplitude_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,33 +19,27 @@ include_directories(include/)
 
 enable_testing()
 
-set(absi_libs cartesian polar amplitude)
-
-set(sources
-    ${src_files}
-    ${header_files}
-    ${test_files}
-    )
-
-# PowArray library
-add_library(powarray src/powarray.cpp src/powmatrix.cpp src/absi/polar.cpp src/absi/cartesian.cpp)
-
 # Amplitude test
 add_library(amplitude src/amplitude.cpp)
 add_executable(amplitude_test test/amplitude_test.cpp)
 target_link_libraries(amplitude_test amplitude powarray GTest::gtest_main)
 
-# ABStract Interpretation (ABSI) tests
-# Encompasses cartesian intervals test and polar intervals tests
 add_library(cartesian src/absi/cartesian.cpp)
 target_link_libraries(cartesian amplitude)
 add_library(polar src/absi/polar.cpp)
+target_link_libraries(polar amplitude)
+
+# PowArray library
+add_library(powarray src/powarray.cpp src/powmatrix.cpp)
+target_link_libraries(powarray cartesian polar)
 
 add_library(absi INTERFACE)
-target_link_libraries(absi INTERFACE amplitude cartesian polar powarray)
+target_link_libraries(absi INTERFACE powarray)
 
-add_executable(absi_test test/absi_test.cpp)
-target_link_libraries(absi_test absi GTest::gtest_main)
+# ABStract Interpretation (ABSI) tests
+# Encompasses cartesian intervals test and polar intervals tests
+add_executable(absi_test test/absi_test.cpp src/powarray.cpp)
+target_link_libraries(absi_test powarray GTest::gtest_main)
 
 # Diagram test
 add_library(diagram STATIC src/diagram.cpp src/random-diagram.cpp)


### PR DESCRIPTION
This PR comes with multiple improvements for builds (and CI builds).

While not perfect, build times are way better:
* Before: 23.626 +- 0.468, 80 objects, 87 files
* After: 15.347 +- 0.434 seconds, 53 objects, 60 files